### PR TITLE
Bump token key format to prevent BC issue

### DIFF
--- a/src/TreeHouse/Keystone/Client/TokenPool.php
+++ b/src/TreeHouse/Keystone/Client/TokenPool.php
@@ -15,6 +15,8 @@ use TreeHouse\Keystone\Client\Model\Token;
 
 class TokenPool
 {
+    const TOKEN_KEY_FORMAT = 'keystone_token_3_%s';
+
     /**
      * @var Tenant
      */
@@ -204,6 +206,6 @@ class TokenPool
      */
     private function getCacheKey()
     {
-        return sprintf('keystone_token_%s', rawurlencode($this->tenant->getTokenUrl()));
+        return sprintf(self::TOKEN_KEY_FORMAT, rawurlencode($this->tenant->getTokenUrl()));
     }
 }

--- a/tests/TreeHouse/Keystone/Tests/Functional/ClientTest.php
+++ b/tests/TreeHouse/Keystone/Tests/Functional/ClientTest.php
@@ -11,6 +11,7 @@ use TreeHouse\Cache\Driver\ArrayDriver;
 use TreeHouse\Cache\Serializer\JsonSerializer;
 use TreeHouse\Keystone\Client\ClientFactory;
 use TreeHouse\Keystone\Client\Model\Tenant;
+use TreeHouse\Keystone\Client\TokenPool;
 use TreeHouse\Keystone\Test\Server;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
@@ -171,7 +172,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     private function getTokenKey()
     {
-        return sprintf('keystone_token_%s', rawurlencode($this->url));
+        return sprintf(TokenPool::TOKEN_KEY_FORMAT, rawurlencode($this->url));
     }
 
     /**


### PR DESCRIPTION
Older versions use php serialize to cache the token. Then newer version uses json, but it crashes when it tries to decode a serialized version of the token. Using a new key format should prevent this issue, meaning both a newer and an older version can work together (app server and worker server both accessing the same cache server).