### PR TITLE
Remove psr7 version lock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     "psr/log": "^1.0",
     "psr/http-message": "^1.0",
     "guzzlehttp/guzzle": "^6.0",
-    "guzzlehttp/psr7": "1.2.3",
     "treehouselabs/cache": "^2.0"
   },
   "require-dev": {


### PR DESCRIPTION
The version lock prevents us from upgrading to guzzlehttp/guzzle 6.2.2 and keeps us on 6.2.0 which has a security vulnerability.

Rel https://github.com/treehouselabs/keystone-client/pull/14/files#r96197285